### PR TITLE
Fix main 'vg-analytics' in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "videogular-angulartics",
   "version": "1.0.0",
-  "main": "./analytics.js",
+  "main": "./vg-analytics.js",
   "dependencies": {
     "videogular": "latest",
     "angulartics": "latest"


### PR DESCRIPTION
The Wiredep can not add files , because of the wrong file name in the mian bower.json
